### PR TITLE
Remove source from payload

### DIFF
--- a/lib/convertLcovToCoveralls.js
+++ b/lib/convertLcovToCoveralls.js
@@ -40,7 +40,6 @@ const convertLcovFileObject = (file, filepath) => {
   return {
     name: path.relative(rootpath, path.resolve(rootpath, file.file)).split(path.sep).join('/'),
     source_digest: md5,
-    source,
     coverage,
     branches,
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coveralls-next",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "coveralls-next",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "form-data": "4.0.0",

--- a/test/convertLcovToCoveralls.js
+++ b/test/convertLcovToCoveralls.js
@@ -22,7 +22,6 @@ describe('convertLcovToCoveralls', () => {
       output.source_files[0].should.have.property('branches');
 
       output.source_files[0].name.should.equal('index.js');
-      output.source_files[0].source_digest.should.equal('aff0ba2a416519a682536c27db3f08a8');
       output.source_files[0].coverage[54].should.equal(0);
       output.source_files[0].coverage[60].should.equal(0);
       done();
@@ -72,7 +71,6 @@ describe('convertLcovToCoveralls', () => {
     convertLcovToCoveralls(input, { filepath: libpath }, (err, output) => {
       should.not.exist(err);
       output.source_files[0].name.should.equal('index.js');
-      output.source_files[0].source_digest.should.equal('aff0ba2a416519a682536c27db3f08a8');
       done();
     });
   });

--- a/test/convertLcovToCoveralls.js
+++ b/test/convertLcovToCoveralls.js
@@ -16,8 +16,13 @@ describe('convertLcovToCoveralls', () => {
     const libpath = path.join(__dirname, './fixtures/lib');
     convertLcovToCoveralls(input, { filepath: libpath }, (err, output) => {
       should.not.exist(err);
+      output.source_files[0].should.have.property('name');
+      output.source_files[0].should.have.property('source_digest');
+      output.source_files[0].should.have.property('coverage');
+      output.source_files[0].should.have.property('branches');
+
       output.source_files[0].name.should.equal('index.js');
-      output.source_files[0].source.split('\n').length.should.equal(179);
+      output.source_files[0].source_digest.should.equal('aff0ba2a416519a682536c27db3f08a8');
       output.source_files[0].coverage[54].should.equal(0);
       output.source_files[0].coverage[60].should.equal(0);
       done();
@@ -67,7 +72,7 @@ describe('convertLcovToCoveralls', () => {
     convertLcovToCoveralls(input, { filepath: libpath }, (err, output) => {
       should.not.exist(err);
       output.source_files[0].name.should.equal('index.js');
-      output.source_files[0].source.split('\n').length.should.equal(179);
+      output.source_files[0].source_digest.should.equal('aff0ba2a416519a682536c27db3f08a8');
       done();
     });
   });


### PR DESCRIPTION
`source` is no longer a required parameter. Given a large enough code base with enough tests, the payload including `source` could exceed 100 mb and be rejected by Cloudflare via `413 Request Entity Too Large`.