### PR TITLE
chore: align v4.2.0 in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coveralls-next",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "coveralls-next",
-      "version": "4.1.2",
+      "version": "4.2.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "form-data": "4.0.0",


### PR DESCRIPTION
The package version wasn't updated in the lockfile in fbb6cde58d5ffaa13bd45e856190ac11586c2758. This fixes that.